### PR TITLE
Allow for name difference

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 ### JetBrains
 .idea/
+
+### opctl
+args*.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes will be documented in this file in accordance with
 
 ## \[Unreleased]
 
+## \[2.0.3] - 2017-11-08
+
+### Changed
+
+- update pkg to allow for differences between property displayName and PropertyId (used in the url)
+
 ## \[2.0.2] - 2017-10-22
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -15,20 +15,20 @@ format
 ## install
 
 ```shell
-opctl pkg install github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.2
+opctl pkg install github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.3
 ```
 
 ## run
 
 ```
-opctl run github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.2
+opctl run github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.3
 ```
 
 ## compose
 
 ```yaml
 op:
-  pkg: { ref: github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.2 }
+  pkg: { ref: github.com/opspec-pkgs/azure.apimanagement.properties.set#2.0.3 }
   inputs:
     subscriptionId:
     loginId:

--- a/index.js
+++ b/index.js
@@ -38,7 +38,6 @@ const getPropertyId = async (credentials, propertyName) => {
 };
 
 const createOrUpdate = async (credentials, property) => {
-    console.log('create/update api management property');
     const propertyId = await getPropertyId(credentials, property.name);
 
     const url = new URL(

--- a/op.yml
+++ b/op.yml
@@ -45,10 +45,10 @@ inputs:
       constraints: { enum: [user, sp]}
       description: type of login; 'user' (default) or 'sp' for service principal
       default: user
-version: 2.0.1
+version: 2.0.3
 run:
   container:
-    image: { ref: 'opspecpkgs/azure.apimanagement.properties.set:2.0.1' }
+    image: { ref: 'opspecpkgs/azure.apimanagement.properties.set:2.0.3' }
     cmd: [node, /index.js]
     files:
       /index.js:

--- a/op.yml
+++ b/op.yml
@@ -53,6 +53,7 @@ run:
     files:
       /index.js:
       /properties.json: $(properties)
+      /propertyLister.js:
     envVars:
       subscriptionId:
       loginId:

--- a/propertyLister.js
+++ b/propertyLister.js
@@ -1,4 +1,9 @@
+const msRestAzure = require('ms-rest-azure');
+const { URL } = require('url');
 class PropertyLister {
+    constructor(){
+        this.list = null;
+    }
     /**
      * Lists existing properties.
      * note: results will be retrieved only once; subsequent calls will return cached results
@@ -25,13 +30,15 @@ class PropertyLister {
             };
 
             console.log('listing api management properties');
-            const result = await azureServiceClient.sendRequest(options);
+            this.list = azureServiceClient.sendRequest(options)
+            .then(result => {
+                if (result.error) {
+                    throw new Error(JSON.stringify(propertyList.error));
+                }
 
-            if (result.error) {
-                throw new Error(JSON.stringify(propertyList.error));
-            }
-            this.list = result.value;
-            console.log('api management properties listed');
+                console.log('api management properties listed');
+                return result.value;
+            });
         }
         return this.list;
     }

--- a/propertyLister.js
+++ b/propertyLister.js
@@ -1,0 +1,40 @@
+class PropertyLister {
+    /**
+     * Lists existing properties.
+     * note: results will be retrieved only once; subsequent calls will return cached results
+     * @param credentials
+     * @return {Promise<*>}
+     */
+    async listProperties(credentials) {
+        if (!this.list) {
+            const url = new URL(
+                'https://management.azure.com/' +
+                `subscriptions/${process.env.subscriptionId}/` +
+                `resourceGroups/${process.env.resourceGroup}/` +
+                'providers/Microsoft.ApiManagement/' +
+                `service/${process.env.apiManagementServiceName}/` +
+                `properties` +
+                '?api-version=2017-03-01');
+
+            // see https://github.com/Azure/azure-sdk-for-node/tree/bf6473eae7faca1ca1cf1375ee53c6fc214ca1b1/runtime/ms-rest-azure#using-the-generic-authenticated-azureserviceclient-to-make-custom-requests-to-azure
+            const azureServiceClient = new msRestAzure.AzureServiceClient(credentials);
+
+            let options = {
+                method: 'GET',
+                url: url.href
+            };
+
+            console.log('listing api management properties');
+            const result = await azureServiceClient.sendRequest(options);
+
+            if (result.error) {
+                throw new Error(JSON.stringify(propertyList.error));
+            }
+            this.list = result.value;
+            console.log('api management properties listed');
+        }
+        return this.list;
+    }
+}
+
+module.exports = new PropertyLister();


### PR DESCRIPTION
The update allows for difference between the displayName and the Name properties. The Name property is used in the URL and will be a unique GUID if the property was originally created via the portal, if originally created with this pkg it Name will equal the displayName.